### PR TITLE
fintech-ui: add proxy.dev.conf to run directly against the dev environment

### DIFF
--- a/fintech-examples/fintech-ui/package.json
+++ b/fintech-examples/fintech-ui/package.json
@@ -5,6 +5,7 @@
     "ng": "ng",
     "openapi-gen": "openapi-generator generate -g typescript-angular -o src/app/api -i ../fintech-api/src/main/resources/static/fintech_api.yml",
     "start": "ng serve --proxy-config=proxy.conf.json",
+    "start:dev": "ng serve --proxy-config=proxy-dev.conf.json",
     "start:docker": "ng serve --proxy-config=proxy-docker.conf.json",
     "build": "ng build",
     "build:prod": "ng build --prod",

--- a/fintech-examples/fintech-ui/proxy-dev.conf.json
+++ b/fintech-examples/fintech-ui/proxy-dev.conf.json
@@ -1,0 +1,11 @@
+{
+  "/fintech-api-proxy/*": {
+    "target": "https://obg-dev-fintechui.cloud.adorsys.de/fintech-api-proxy",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "debug",
+    "pathRewrite": {
+      "^/fintech-api-proxy": ""
+    }
+  }
+}


### PR DESCRIPTION
Now you can directly develop against dev backend with npm run start:dev.