### PR TITLE
Stateless GET authorization

### DIFF
--- a/opba-protocols/xs2a-protocol/src/main/java/de/adorsys/opba/protocol/xs2a/constant/GlobalConst.java
+++ b/opba-protocols/xs2a-protocol/src/main/java/de/adorsys/opba/protocol/xs2a/constant/GlobalConst.java
@@ -7,6 +7,9 @@ import lombok.experimental.UtilityClass;
 public class GlobalConst {
 
     public static final String CONTEXT = "CONTEXT";
+    public static final String LAST_VALIDATION_ISSUES = "LAST_VALIDATION_ISSUES";
+    public static final String LAST_REDIRECTION_TARGET = "LAST_REDIRECTION_TARGET";
+
     public static final String BEFORE_VALIDATION_CONTEXT = "BEFORE_VALIDATION_CONTEXT";
     public static final String RESULT = "RESULT";
 

--- a/opba-protocols/xs2a-protocol/src/main/java/de/adorsys/opba/protocol/xs2a/entrypoint/OutcomeMapper.java
+++ b/opba-protocols/xs2a-protocol/src/main/java/de/adorsys/opba/protocol/xs2a/entrypoint/OutcomeMapper.java
@@ -1,20 +1,18 @@
 package de.adorsys.opba.protocol.xs2a.entrypoint;
 
-import de.adorsys.opba.protocol.api.dto.ValidationIssue;
 import de.adorsys.opba.protocol.api.dto.result.fromprotocol.Result;
 import de.adorsys.opba.protocol.api.dto.result.fromprotocol.dialog.AuthorizationRequiredResult;
 import de.adorsys.opba.protocol.api.dto.result.fromprotocol.dialog.ConsentAcquiredResult;
-import de.adorsys.opba.protocol.api.dto.result.fromprotocol.dialog.ValidationErrorResult;
 import de.adorsys.opba.protocol.api.dto.result.fromprotocol.error.ErrorResult;
 import de.adorsys.opba.protocol.api.dto.result.fromprotocol.ok.SuccessResult;
 import de.adorsys.opba.protocol.xs2a.domain.dto.messages.ConsentAcquired;
 import de.adorsys.opba.protocol.xs2a.domain.dto.messages.Redirect;
 import de.adorsys.opba.protocol.xs2a.domain.dto.messages.Response;
 import de.adorsys.opba.protocol.xs2a.domain.dto.messages.ValidationProblem;
+import de.adorsys.opba.protocol.xs2a.entrypoint.dto.ContextBasedValidationErrorResult;
 import lombok.RequiredArgsConstructor;
 
 import java.net.URI;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
@@ -72,18 +70,4 @@ public class OutcomeMapper<T> {
         }
     }
 
-    private static class ContextBasedValidationErrorResult<T> extends ValidationErrorResult<T, Set<ValidationIssue>> {
-
-        private final String executionId;
-
-        ContextBasedValidationErrorResult(URI redirectionTo, String executionId, Set<ValidationIssue> issues) {
-            super(redirectionTo, issues);
-            this.executionId = executionId;
-        }
-
-        @Override
-        public String authContext() {
-            return executionId;
-        }
-    }
 }

--- a/opba-protocols/xs2a-protocol/src/main/java/de/adorsys/opba/protocol/xs2a/entrypoint/authorization/Xs2aGetAuthorizationState.java
+++ b/opba-protocols/xs2a-protocol/src/main/java/de/adorsys/opba/protocol/xs2a/entrypoint/authorization/Xs2aGetAuthorizationState.java
@@ -5,72 +5,33 @@ import de.adorsys.opba.protocol.api.dto.context.ServiceContext;
 import de.adorsys.opba.protocol.api.dto.request.authorization.AuthorizationRequest;
 import de.adorsys.opba.protocol.api.dto.result.body.AuthStateBody;
 import de.adorsys.opba.protocol.api.dto.result.fromprotocol.Result;
-import de.adorsys.opba.protocol.xs2a.domain.dto.messages.ConsentAcquired;
-import de.adorsys.opba.protocol.xs2a.domain.dto.messages.Redirect;
-import de.adorsys.opba.protocol.xs2a.domain.dto.messages.Response;
-import de.adorsys.opba.protocol.xs2a.entrypoint.OutcomeMapper;
-import de.adorsys.opba.protocol.xs2a.entrypoint.authorization.common.AuthorizationContinuationService;
-import de.adorsys.opba.protocol.xs2a.service.xs2a.context.BaseContext;
+import de.adorsys.opba.protocol.xs2a.entrypoint.dto.ContextBasedValidationErrorResult;
+import de.adorsys.opba.protocol.xs2a.service.xs2a.context.LastViolations;
 import lombok.RequiredArgsConstructor;
 import org.flowable.engine.RuntimeService;
 import org.springframework.stereotype.Service;
 
+import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 
-import static de.adorsys.opba.protocol.xs2a.constant.GlobalConst.CONTEXT;
-import static de.adorsys.opba.protocol.xs2a.service.xs2a.context.ContextMode.MOCK_REAL_CALLS;
+import static de.adorsys.opba.protocol.xs2a.constant.GlobalConst.LAST_REDIRECTION_TARGET;
+import static de.adorsys.opba.protocol.xs2a.constant.GlobalConst.LAST_VALIDATION_ISSUES;
 
 @Service("xs2aGetAuthorizationState")
 @RequiredArgsConstructor
 public class Xs2aGetAuthorizationState implements GetAuthorizationState {
 
-    private final AuthorizationContinuationService continuationService;
     private final RuntimeService runtimeService;
 
     @Override
     public CompletableFuture<Result<AuthStateBody>> execute(ServiceContext<AuthorizationRequest> serviceContext) {
         String executionId = serviceContext.getAuthContext();
-        ensureCallWillBeIdempotentForProcess(executionId);
-        return continuationService.handleAuthorizationProcessContinuation(executionId, OnlyValidationPassMapper::new);
-    }
+        LastViolations issues = (LastViolations) runtimeService.getVariable(executionId, LAST_VALIDATION_ISSUES);
+        String redirectTo = (String) runtimeService.getVariable(executionId, LAST_REDIRECTION_TARGET);
+        URI redirectToAsUri = null == redirectTo ? null : URI.create(redirectTo);
 
-    /**
-     * The call is not going to be idempotent as it will change database state, redirect code etc. But in terms of
-     * process itself we need to be sure that it is idempotent as it is used for GET request.
-     * Process in 'MOCK' (validation) state should be always idempotent.
-     */
-    private void ensureCallWillBeIdempotentForProcess(String executionId) {
-        BaseContext ctx = (BaseContext) runtimeService.getVariable(executionId, CONTEXT);
-
-        if (MOCK_REAL_CALLS != ctx.getMode()) {
-            throw new IllegalStateException("Unable to get authorization state - non-idempotent mode: " + ctx.getMode());
-        }
-    }
-
-    private static class OnlyValidationPassMapper extends OutcomeMapper<AuthStateBody> {
-
-        OnlyValidationPassMapper(CompletableFuture<Result<AuthStateBody>> channel) {
-            super(channel, null);
-        }
-
-        @Override
-        public void onSuccess(Response responseResult) {
-            throw new IllegalStateException("Unexpected SUCCESS state");
-        }
-
-        @Override
-        public void onRedirect(Redirect redirectResult) {
-            throw new IllegalStateException("Unexpected REDIRECT state");
-        }
-
-        @Override
-        public void onConsentAcquired(ConsentAcquired acquired) {
-            throw new IllegalStateException("Unexpected CONSENT ACQUIRED state");
-        }
-
-        @Override
-        public void onError() {
-            throw new IllegalStateException("Unexpected ERROR state");
-        }
+        return CompletableFuture.completedFuture(
+            new ContextBasedValidationErrorResult<>(redirectToAsUri, executionId, issues.getViolations())
+        );
     }
 }

--- a/opba-protocols/xs2a-protocol/src/main/java/de/adorsys/opba/protocol/xs2a/entrypoint/dto/ContextBasedValidationErrorResult.java
+++ b/opba-protocols/xs2a-protocol/src/main/java/de/adorsys/opba/protocol/xs2a/entrypoint/dto/ContextBasedValidationErrorResult.java
@@ -1,0 +1,22 @@
+package de.adorsys.opba.protocol.xs2a.entrypoint.dto;
+
+import de.adorsys.opba.protocol.api.dto.ValidationIssue;
+import de.adorsys.opba.protocol.api.dto.result.fromprotocol.dialog.ValidationErrorResult;
+
+import java.net.URI;
+import java.util.Set;
+
+public class ContextBasedValidationErrorResult<T> extends ValidationErrorResult<T, Set<ValidationIssue>> {
+
+    private final String executionId;
+
+    public ContextBasedValidationErrorResult(URI redirectionTo, String executionId, Set<ValidationIssue> issues) {
+        super(redirectionTo, issues);
+        this.executionId = executionId;
+    }
+
+    @Override
+    public String authContext() {
+        return executionId;
+    }
+}

--- a/opba-protocols/xs2a-protocol/src/main/java/de/adorsys/opba/protocol/xs2a/service/validation/Xs2aRestorePreValidationContext.java
+++ b/opba-protocols/xs2a-protocol/src/main/java/de/adorsys/opba/protocol/xs2a/service/validation/Xs2aRestorePreValidationContext.java
@@ -1,17 +1,30 @@
 package de.adorsys.opba.protocol.xs2a.service.validation;
 
+import de.adorsys.opba.protocol.xs2a.service.ContextUtil;
+import de.adorsys.opba.protocol.xs2a.service.xs2a.context.BaseContext;
+import de.adorsys.opba.protocol.xs2a.service.xs2a.context.LastViolations;
 import org.flowable.engine.delegate.DelegateExecution;
 import org.flowable.engine.delegate.JavaDelegate;
 import org.springframework.stereotype.Service;
 
 import static de.adorsys.opba.protocol.xs2a.constant.GlobalConst.BEFORE_VALIDATION_CONTEXT;
 import static de.adorsys.opba.protocol.xs2a.constant.GlobalConst.CONTEXT;
+import static de.adorsys.opba.protocol.xs2a.constant.GlobalConst.LAST_REDIRECTION_TARGET;
+import static de.adorsys.opba.protocol.xs2a.constant.GlobalConst.LAST_VALIDATION_ISSUES;
 
 @Service("xs2aRestorePreValidationContext")
 public class Xs2aRestorePreValidationContext implements JavaDelegate {
 
     @Override
     public void execute(DelegateExecution execution) {
+        execution.setVariable(
+            LAST_VALIDATION_ISSUES,
+            new LastViolations(ContextUtil.getContext(execution, BaseContext.class).getViolations())
+        );
+        execution.setVariable(
+            LAST_REDIRECTION_TARGET,
+            ContextUtil.getContext(execution, BaseContext.class).getRedirectTo()
+        );
         execution.setVariable(CONTEXT, execution.getVariable(BEFORE_VALIDATION_CONTEXT));
         execution.removeVariable(BEFORE_VALIDATION_CONTEXT);
     }

--- a/opba-protocols/xs2a-protocol/src/main/java/de/adorsys/opba/protocol/xs2a/service/xs2a/context/BaseContext.java
+++ b/opba-protocols/xs2a-protocol/src/main/java/de/adorsys/opba/protocol/xs2a/service/xs2a/context/BaseContext.java
@@ -38,7 +38,8 @@ public class BaseContext {
      */
     private String redirectCodeIfAuthContinued;
 
-    private final Set<ValidationIssue> violations = new HashSet<>();
+    private Set<ValidationIssue> violations = new HashSet<>();
+    private String redirectTo;
 
     public String getRequestId() {
         return this.sagaId;

--- a/opba-protocols/xs2a-protocol/src/main/java/de/adorsys/opba/protocol/xs2a/service/xs2a/context/LastViolations.java
+++ b/opba-protocols/xs2a-protocol/src/main/java/de/adorsys/opba/protocol/xs2a/service/xs2a/context/LastViolations.java
@@ -1,0 +1,20 @@
+package de.adorsys.opba.protocol.xs2a.service.xs2a.context;
+
+import de.adorsys.opba.protocol.api.dto.ValidationIssue;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Helper class to be very specific of what to save.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LastViolations {
+
+    private Set<ValidationIssue> violations = new HashSet<>();
+}


### PR DESCRIPTION
All violations are perisisted in parent process. Now they are retreived completely stateless
Fixes #380 