### PR TITLE
Obg 782/feature show fields in account consent ui

### DIFF
--- a/consent-ui/src/app/ais/components/consent-info/consent-info.component.ts
+++ b/consent-ui/src/app/ais/components/consent-info/consent-info.component.ts
@@ -13,8 +13,8 @@ import { ConsentUtil } from '../../common/consent-util';
 export class ConsentInfoComponent implements OnInit {
   accountAccessLevel = AccountAccessLevel;
 
-  public finTechName = StubUtil.FINTECH_NAME;
-  public aspspName = StubUtil.ASPSP_NAME;
+  public finTechName: string;
+  public aspspName: string;
 
   public aisConsent: AisConsentToGrant;
 
@@ -25,6 +25,8 @@ export class ConsentInfoComponent implements OnInit {
   ngOnInit() {
     this.activatedRoute.params.subscribe(res => {
       this.authorizationId = res.authId;
+      this.aspspName = this.sessionService.getBankName(res.authId);
+      this.finTechName = this.sessionService.getFintechName(res.authId);
       this.aisConsent = ConsentUtil.getOrDefault(this.authorizationId, this.sessionService);
     });
 

--- a/consent-ui/src/app/ais/entry-page/initiation/accounts/accounts-consent-review/accounts-consent-review.component.ts
+++ b/consent-ui/src/app/ais/entry-page/initiation/accounts/accounts-consent-review/accounts-consent-review.component.ts
@@ -29,8 +29,8 @@ export class AccountsConsentReviewComponent implements OnInit {
 
   accountAccessLevel = AccountAccessLevel;
 
-  public finTechName = StubUtil.FINTECH_NAME;
-  public aspspName = StubUtil.ASPSP_NAME;
+  public finTechName: string;
+  public aspspName: string;
   public aisConsent: AisConsentToGrant;
 
   private authorizationId: string;
@@ -39,6 +39,8 @@ export class AccountsConsentReviewComponent implements OnInit {
     this.activatedRoute.parent.parent.params.subscribe(res => {
       this.authorizationId = res.authId;
       this.aisConsent = ConsentUtil.getOrDefault(this.authorizationId, this.sessionService);
+      this.aspspName = this.sessionService.getBankName(res.authId);
+      this.finTechName = this.sessionService.getFintechName(res.authId);
     });
   }
 

--- a/consent-ui/src/app/ais/entry-page/initiation/common/dedicated-access/dedicated-access.component.ts
+++ b/consent-ui/src/app/ais/entry-page/initiation/common/dedicated-access/dedicated-access.component.ts
@@ -26,8 +26,8 @@ export class DedicatedAccessComponent implements OnInit {
 
   public static ROUTE = 'dedicated-account-access';
 
-  public finTechName = StubUtil.FINTECH_NAME;
-  public aspspName = StubUtil.ASPSP_NAME;
+  public finTechName: string;
+  public aspspName: string;
 
   accounts = [new AccountReference()];
   limitedAccountAccessForm: FormGroup;
@@ -39,6 +39,8 @@ export class DedicatedAccessComponent implements OnInit {
     this.wrongIban = this.activatedRoute.snapshot.queryParamMap.get('wrong') === 'true';
     this.activatedRoute.parent.parent.params.subscribe(res => {
       this.authorizationId = res.authId;
+      this.aspspName = this.sessionService.getBankName(res.authId);
+      this.finTechName = this.sessionService.getFintechName(res.authId);
       this.loadDataFromExistingConsent();
     });
   }

--- a/consent-ui/src/app/ais/entry-page/initiation/common/initial-consent/consent-account-access-selection.component.spec.ts
+++ b/consent-ui/src/app/ais/entry-page/initiation/common/initial-consent/consent-account-access-selection.component.spec.ts
@@ -14,6 +14,7 @@ import { DedicatedAccessComponent } from '../dedicated-access/dedicated-access.c
 import { StubUtilTests } from '../../../../common/stub-util-tests';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { UpdateConsentAuthorizationService } from '../../../../../api';
+import { StubUtil } from '../../../../../common/utils/stub-util';
 
 describe('ConsentAccountAccessSelectionComponent', () => {
   let component: ConsentAccountAccessSelectionComponent;
@@ -36,9 +37,9 @@ describe('ConsentAccountAccessSelectionComponent', () => {
           provide: SessionService,
           useValue: {
             getConsentObject: () => new AisConsentToGrant(),
-            hasAisViolation: () => false,
-            hasGeneralViolation: () => false,
-            getConsentState: () => new AuthConsentState([])
+            getConsentState: () => new AuthConsentState([]),
+            getFintechName: (): string => StubUtil.FINTECH_NAME,
+            getBankName: (): string => StubUtil.ASPSP_NAME
           }
         }
       ],

--- a/consent-ui/src/app/ais/entry-page/initiation/common/initial-consent/consent-account-access-selection.component.ts
+++ b/consent-ui/src/app/ais/entry-page/initiation/common/initial-consent/consent-account-access-selection.component.ts
@@ -15,8 +15,8 @@ import { ApiHeaders } from '../../../../../api/api.headers';
   styleUrls: ['./consent-account-access-selection.component.scss']
 })
 export class ConsentAccountAccessSelectionComponent implements OnInit {
-  public finTechName = StubUtil.FINTECH_NAME;
-  public aspspName = StubUtil.ASPSP_NAME;
+  public finTechName: string;
+  public aspspName: string;
 
   @Input() accountAccesses: Access[];
   @Input() consentReviewPage: string;
@@ -42,6 +42,8 @@ export class ConsentAccountAccessSelectionComponent implements OnInit {
   ngOnInit() {
     this.activatedRoute.parent.parent.params.subscribe(res => {
       this.authorizationId = res.authId;
+      this.aspspName = this.sessionService.getBankName(res.authId);
+      this.finTechName = this.sessionService.getFintechName(res.authId);
       this.state = this.sessionService.getConsentState(this.authorizationId, () => new AuthConsentState());
       if (!this.hasInputs()) {
         this.moveToReviewConsent();

--- a/consent-ui/src/app/ais/entry-page/initiation/consent-initiate/consent-initiate.component.ts
+++ b/consent-ui/src/app/ais/entry-page/initiation/consent-initiate/consent-initiate.component.ts
@@ -49,6 +49,10 @@ export class ConsentInitiateComponent implements OnInit {
 
   private initiateConsentSession(authorizationId: string, redirectCode: string) {
     this.authStateConsentAuthorizationService.authUsingGET(authorizationId, redirectCode, 'response').subscribe(res => {
+      // setting bank and fintech names
+      this.sessionService.setBankName(authorizationId, (res.body as ConsentAuth).bankName);
+      this.sessionService.setFintechName(authorizationId, (res.body as ConsentAuth).fintechName);
+
       this.sessionService.setRedirectCode(authorizationId, res.headers.get(ApiHeaders.REDIRECT_CODE));
       this.navigate(authorizationId, res.body);
     });

--- a/consent-ui/src/app/ais/entry-page/initiation/consent-sharing/consent-sharing.component.ts
+++ b/consent-ui/src/app/ais/entry-page/initiation/consent-sharing/consent-sharing.component.ts
@@ -20,8 +20,8 @@ export class ConsentSharingComponent implements OnInit {
   redirectTo: string;
   isAccount = true;
 
-  public finTechName = StubUtil.FINTECH_NAME;
-  public aspspName = StubUtil.ASPSP_NAME;
+  public finTechName: string;
+  public aspspName: string;
   public aisConsent: AisConsentToGrant;
 
   private authorizationId: string;
@@ -38,6 +38,9 @@ export class ConsentSharingComponent implements OnInit {
     this.authorizationId = this.activatedRoute.parent.snapshot.params.authId;
     const redirectCode = this.sessionService.getRedirectCode(this.authorizationId);
     this.aisConsent = ConsentUtil.getOrDefault(this.authorizationId, this.sessionService);
+
+    this.aspspName = this.sessionService.getBankName(this.authorizationId);
+    this.finTechName = this.sessionService.getFintechName(this.authorizationId);
 
     this.authStateConsentAuthorizationService
       .authUsingGET(this.authorizationId, redirectCode, 'response')

--- a/consent-ui/src/app/ais/entry-page/initiation/transactions/transactions-consent-review/transactions-consent-review.component.ts
+++ b/consent-ui/src/app/ais/entry-page/initiation/transactions/transactions-consent-review/transactions-consent-review.component.ts
@@ -28,8 +28,8 @@ export class TransactionsConsentReviewComponent implements OnInit {
   public static ROUTE = SharedRoutes.REVIEW;
   accountAccessLevel = AccountAccessLevel;
 
-  public finTechName = StubUtil.FINTECH_NAME;
-  public aspspName = StubUtil.ASPSP_NAME;
+  public finTechName: string;
+  public aspspName: string;
 
   public aisConsent: AisConsentToGrant;
 
@@ -38,6 +38,8 @@ export class TransactionsConsentReviewComponent implements OnInit {
   ngOnInit() {
     this.activatedRoute.parent.parent.params.subscribe(res => {
       this.authorizationId = res.authId;
+      this.aspspName = this.sessionService.getBankName(res.authId);
+      this.finTechName = this.sessionService.getFintechName(res.authId);
       this.aisConsent = ConsentUtil.getOrDefault(this.authorizationId, this.sessionService);
     });
   }

--- a/consent-ui/src/app/ais/result-page/result-page.component.ts
+++ b/consent-ui/src/app/ais/result-page/result-page.component.ts
@@ -17,7 +17,7 @@ import { Location } from '@angular/common';
 export class ResultPageComponent implements OnInit {
   public static ROUTE = 'consent-result';
 
-  public finTechName = StubUtil.FINTECH_NAME;
+  public finTechName: string;
   public title = 'Consent has been granted';
   redirectTo: string;
 
@@ -37,6 +37,7 @@ export class ResultPageComponent implements OnInit {
   ngOnInit() {
     this.route = this.activatedRoute.snapshot;
     this.authorizationId = this.route.parent.params.authId;
+    this.finTechName = this.sessionService.getFintechName(this.authorizationId);
     const redirectCode = this.route.queryParams.redirectCode;
     this.aisConsent = ConsentUtil.getOrDefault(this.authorizationId, this.sessionService);
     this.loadRedirectUri(this.authorizationId, redirectCode);

--- a/consent-ui/src/app/ais/to-aspsp-page/to-aspsp-redirection.component.ts
+++ b/consent-ui/src/app/ais/to-aspsp-page/to-aspsp-redirection.component.ts
@@ -19,8 +19,8 @@ import { UpdateConsentAuthorizationService, DenyRequest } from '../../api';
 export class ToAspspRedirectionComponent implements OnInit {
   public static ROUTE = 'to-aspsp-redirection';
 
-  public finTechName = StubUtil.FINTECH_NAME;
-  public aspspName = StubUtil.ASPSP_NAME;
+  public finTechName: string;
+  public aspspName: string;
   public account = Action.ACCOUNT;
 
   redirectTo: string;
@@ -39,6 +39,8 @@ export class ToAspspRedirectionComponent implements OnInit {
   ngOnInit() {
     this.activatedRoute.parent.params.subscribe(res => {
       this.authorizationId = res.authId;
+      this.aspspName = this.sessionService.getBankName(res.authId);
+      this.finTechName = this.sessionService.getFintechName(res.authId);
       this.aisConsent = ConsentUtil.getOrDefault(this.authorizationId, this.sessionService);
       this.loadRedirectUri();
     });

--- a/consent-ui/src/app/common/session.service.ts
+++ b/consent-ui/src/app/common/session.service.ts
@@ -12,12 +12,28 @@ export class SessionService {
   public getTTL(authorizationId: string): string {
     return sessionStorage.getItem(authorizationId + Session.COOKIE_TTL);
   }
+
+  public getRedirectCode(authorizationId: string): string {
+    return sessionStorage.getItem(authorizationId + Session.REDIRECT_CODE);
+  }
   public setRedirectCode(authorizationId: string, redirectCode: string) {
     sessionStorage.setItem(authorizationId + Session.REDIRECT_CODE, redirectCode);
   }
 
-  public getRedirectCode(authorizationId: string): string {
-    return sessionStorage.getItem(authorizationId + Session.REDIRECT_CODE);
+  public getFintechName(authorizationId: string): string {
+    return sessionStorage.getItem(authorizationId + Session.FINTECH_NAME);
+  }
+
+  public setFintechName(authorizationId: string, fintechName: string) {
+    sessionStorage.setItem(authorizationId + Session.FINTECH_NAME, fintechName);
+  }
+
+  public getBankName(authorizationId: string): string {
+    return sessionStorage.getItem(authorizationId + Session.BANK_NAME);
+  }
+
+  public setBankName(authorizationId: string, bankName: string) {
+    sessionStorage.setItem(authorizationId + Session.BANK_NAME, bankName);
   }
 
   public setConsentState(authorizationId: string, consentState: any) {
@@ -82,6 +98,8 @@ enum Session {
   CONSENT_OBJECT = ':CONSENT_OBJECT',
   PAYMENT_OBJECT = ':PAYMENT_OBJECT',
   PAYMENT_STATE = ':PAYMENT_STATE',
+  FINTECH_NAME = ':FINTECH_NAME',
+  BANK_NAME = ':BANK_NAME',
   XSRF_TOKEN = 'XSRF_TOKEN',
   COOKIE_TTL = 'Cookie-TTL'
 }

--- a/consent-ui/src/app/pis/consent-payment-access-selection/consent-payment-access-selection.component.spec.ts
+++ b/consent-ui/src/app/pis/consent-payment-access-selection/consent-payment-access-selection.component.spec.ts
@@ -13,6 +13,7 @@ import { AuthConsentState } from '../../ais/common/dto/auth-state';
 import { PaymentsConsentReviewComponent } from '../payments-consent-review/payments-consent-review.component';
 import { ConsentPaymentAccessSelectionComponent } from './consent-payment-access-selection.component';
 import { PisPayment } from '../common/models/pis-payment.model';
+import { StubUtil } from '../../common/utils/stub-util';
 
 describe('ConsentPaymentAccessSelectionComponent', () => {
   let component: ConsentPaymentAccessSelectionComponent;
@@ -36,9 +37,10 @@ describe('ConsentPaymentAccessSelectionComponent', () => {
           useValue: {
             getPaymentObject: () => new PisPayment(),
             getPaymentState: () => new AisConsentToGrant(),
-            hasPisViolation: () => false,
             hasGeneralViolation: () => false,
-            getConsentState: () => new AuthConsentState([])
+            getConsentState: () => new AuthConsentState([]),
+            getFintechName: (): string => StubUtil.FINTECH_NAME,
+            getBankName: (): string => StubUtil.ASPSP_NAME
           }
         }
       ],

--- a/consent-ui/src/app/pis/consent-payment-access-selection/consent-payment-access-selection.component.ts
+++ b/consent-ui/src/app/pis/consent-payment-access-selection/consent-payment-access-selection.component.ts
@@ -16,8 +16,8 @@ import { PisPayment } from '../common/models/pis-payment.model';
   styleUrls: ['./consent-payment-access-selection.component.scss']
 })
 export class ConsentPaymentAccessSelectionComponent implements OnInit {
-  public finTechName = StubUtil.FINTECH_NAME;
-  public aspspName = StubUtil.ASPSP_NAME;
+  public finTechName: string;
+  public aspspName: string;
 
   @Input() paymentReviewPage: string;
 
@@ -40,6 +40,8 @@ export class ConsentPaymentAccessSelectionComponent implements OnInit {
   ngOnInit() {
     this.activatedRoute.parent.parent.params.subscribe(res => {
       this.authorizationId = res.authId;
+      this.aspspName = this.sessionService.getBankName(res.authId);
+      this.finTechName = this.sessionService.getFintechName(res.authId);
       this.state = this.sessionService.getPaymentState(this.authorizationId, () => new AuthConsentState());
       if (!this.hasGeneralViolations()) {
         this.moveToReviewPayment();

--- a/consent-ui/src/app/pis/initiation/payment-initiate.component.ts
+++ b/consent-ui/src/app/pis/initiation/payment-initiate.component.ts
@@ -48,6 +48,11 @@ export class PaymentInitiateComponent implements OnInit {
   private initiatePaymentSession(authorizationId: string, redirectCode: string) {
     this.authStateConsentAuthorizationService.authUsingGET(authorizationId, redirectCode, 'response').subscribe(res => {
       this.sessionService.setRedirectCode(authorizationId, res.headers.get(ApiHeaders.REDIRECT_CODE));
+
+      // setting bank and fintech names
+      this.sessionService.setBankName(authorizationId, (res.body as ConsentAuth).bankName);
+      this.sessionService.setFintechName(authorizationId, (res.body as ConsentAuth).fintechName);
+
       this.navigate(authorizationId, res.body);
     });
   }

--- a/consent-ui/src/app/pis/payments-consent-review/payments-consent-review.component.ts
+++ b/consent-ui/src/app/pis/payments-consent-review/payments-consent-review.component.ts
@@ -19,8 +19,8 @@ import { PisPayment } from '../common/models/pis-payment.model';
 export class PaymentsConsentReviewComponent implements OnInit {
   public static ROUTE = SharedRoutes.REVIEW;
   accountAccessLevel = AccountAccessLevel;
-  public finTechName = StubUtil.FINTECH_NAME;
-  public aspspName = StubUtil.ASPSP_NAME;
+  public finTechName: string;
+  public aspspName: string;
   public payment: PisPayment;
   private authorizationId: string;
 
@@ -36,6 +36,8 @@ export class PaymentsConsentReviewComponent implements OnInit {
   ngOnInit() {
     this.activatedRoute.parent.parent.params.subscribe(res => {
       this.authorizationId = res.authId;
+      this.aspspName = this.sessionService.getBankName(res.authId);
+      this.finTechName = this.sessionService.getFintechName(res.authId);
       this.payment = PaymentUtil.getOrDefault(this.authorizationId, this.sessionService);
     });
   }

--- a/consent-ui/src/app/pis/result-page/result-page.component.ts
+++ b/consent-ui/src/app/pis/result-page/result-page.component.ts
@@ -17,7 +17,7 @@ import { PisPayment } from '../common/models/pis-payment.model';
 export class ResultPageComponent implements OnInit {
   public static ROUTE = 'consent-result';
 
-  public finTechName = StubUtil.FINTECH_NAME;
+  public finTechName: string;
   public title = 'Payment was successful';
   public subtitle = 'Paid 100EUR to IBAN12345';
   redirectTo: string;
@@ -38,6 +38,7 @@ export class ResultPageComponent implements OnInit {
   ngOnInit() {
     this.route = this.activatedRoute.snapshot;
     this.authorizationId = this.route.parent.params.authId;
+    this.finTechName = this.sessionService.getFintechName(this.authorizationId);
     const redirectCode = this.route.queryParams.redirectCode;
     this.payment = PaymentUtil.getOrDefault(this.authorizationId, this.sessionService);
     this.loadRedirectUri(this.authorizationId, redirectCode);

--- a/consent-ui/src/app/pis/to-aspsp-page/to-aspsp-page.component.ts
+++ b/consent-ui/src/app/pis/to-aspsp-page/to-aspsp-page.component.ts
@@ -17,8 +17,8 @@ import { PisPayment } from '../common/models/pis-payment.model';
 export class ToAspspPageComponent implements OnInit {
   public static ROUTE = 'to-aspsp-redirection';
 
-  public finTechName = StubUtil.FINTECH_NAME;
-  public aspspName = StubUtil.ASPSP_NAME;
+  public finTechName: string;
+  public aspspName: string;
   public payment = Action.PAYMENT;
 
   redirectTo: string;
@@ -36,6 +36,8 @@ export class ToAspspPageComponent implements OnInit {
 
   ngOnInit() {
     this.activatedRoute.parent.params.subscribe(res => {
+      this.aspspName = this.sessionService.getBankName(res.authId);
+      this.finTechName = this.sessionService.getFintechName(res.authId);
       this.authorizationId = res.authId;
       this.pisPayment = PaymentUtil.getOrDefault(this.authorizationId, this.sessionService);
       this.loadRedirectUri();


### PR DESCRIPTION
Since for now we receive in ConsentAuth only fintechName and aspspName, these values are stored in session storage and displayed in Consent and payment screens