### PR TITLE
Prevent running gpg:sign plugin before package by avoiding 'develop' …

### DIFF
--- a/.github/workflows/tag-release-candidate-push.yml
+++ b/.github/workflows/tag-release-candidate-push.yml
@@ -27,6 +27,7 @@ jobs:
           GPG_OWNERTRUST: ${{ secrets.GPG_OWNERTRUST }}
           STAGE_ARTIFACTORY_USERNAME: ${{ secrets.GITHUB_USER }}
           STAGE_ARTIFACTORY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          GIT_BRANCH: master # Force branch to resolve to master if git resolution fails - otherwise gitflow-helper uses UNDEFINED branch
 
       - name: Deploy develop artifacts to OpenShift
         run: ./scripts/deploy_openshift_release_candidate.sh

--- a/.github/workflows/tag-release-push.yml
+++ b/.github/workflows/tag-release-push.yml
@@ -30,3 +30,4 @@ jobs:
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GIT_BRANCH: master # Force branch to resolve to master if git resolution fails - otherwise gitflow-helper uses UNDEFINED branch

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,8 @@
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-javadoc-plugin>3.2.0</maven-javadoc-plugin>
 
+        <master-branch-pattern>.*</master-branch-pattern>
+
         <!-- Framework libs -->
         <spring-boot.version>2.2.4.RELEASE</spring-boot.version>
         <aspectj.version>1.9.5</aspectj.version>
@@ -506,7 +508,7 @@
                             <snapshotDeploymentRepository>stage</snapshotDeploymentRepository>
 
                             <!-- Allow to promote on ANY branch because Github Actions checkouts tag, not branch (and forcing both seem impossible) -->
-                            <masterBranchPattern>.*</masterBranchPattern>
+                            <masterBranchPattern>${master-branch-pattern}</masterBranchPattern>
                         </configuration>
                         <executions>
                             <execution>
@@ -614,7 +616,7 @@
                             <snapshotDeploymentRepository>stage</snapshotDeploymentRepository>
 
                             <!-- Allow to promote on ANY branch because Github Actions checkouts tag, not branch (and forcing both seem impossible) -->
-                            <masterBranchPattern>.*</masterBranchPattern>
+                            <masterBranchPattern>${master-branch-pattern}</masterBranchPattern>
                         </configuration>
                         <executions>
                             <execution>

--- a/scripts/mvn_deploy_check_develop.sh
+++ b/scripts/mvn_deploy_check_develop.sh
@@ -7,4 +7,4 @@ echo "$GPG_SECRET_KEY" | base64 --decode | $GPG_EXECUTABLE --import --no-tty --b
 echo "$GPG_OWNERTRUST" | base64 --decode | $GPG_EXECUTABLE --import-ownertrust --no-tty --batch --yes || true
 
 # Deploy is actually skipped because artifact bundle is quite heavy for day-to-day CI/CD. But we sign them and run JavaDocs
-mvn --no-transfer-progress --settings scripts/mvn-release-settings.xml package gpg:sign -Prelease-candidate -DskipTests -B -U;
+mvn --no-transfer-progress --settings scripts/mvn-release-settings.xml package gpg:sign -Dmaster-branch-pattern='!develop' -Prelease-candidate -DskipTests -B -U;


### PR DESCRIPTION
…to trigger gitflow-helper-maven-plugin